### PR TITLE
Change date format from l to DD/MM/YYYY

### DIFF
--- a/tin.user.js
+++ b/tin.user.js
@@ -1028,6 +1028,10 @@ const CSS = `
 
     const locale = unsafeWindow.netflix.reactContext.models.consolidatedLogging.data.loggingConstants.locale;
     i18next.changeLanguage(locale);
+    // Use en-gb as locale for moment in case of locale usage of en-DE in Netflix, to support the date format DD/MM/YYYY
+    moment.defineLocale("en-DE", {
+        parentLocale: "en-gb"
+    });
     moment.locale(locale);
 
     const falcor = new FalcorWrapper(unsafeWindow);


### PR DESCRIPTION
The expiration dates were always 'invalid date' in my browser (firefox) but also on chromium.
Seems like the date format spit out by `availabilityEndDateNear` is **DD**/**MM**/YYYY and not **MM**/**DD**/YYYY as expected by moment.js.
I don't know if the date given by Netflix is dependent on language selection or something else, so some insight would be interesting for me. If this is the case I would try to adopt my PR accordingly.

Nonetheless thanks for this awesome userscript! :+1: 